### PR TITLE
Readme and ruby upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.0
+FROM ruby:2.5.3
 RUN useradd -u 1000 --create-home --home-dir /xyz --shell /bin/bash confy
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5
+FROM ruby:2.6.0
 RUN useradd -u 1000 --create-home --home-dir /xyz --shell /bin/bash confy
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "2.6.0"
+ruby "2.5.3"
 
 gem "rails", "~> 5.2.2"
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "2.5.3"
+ruby "2.6.0"
 
 gem "rails", "~> 5.2.2"
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Confy
-Where the meetings are.
+**The conference's library**
 
 ## Pre-Requisites
 - Ruby (version located on [Gemfile](./Gemfile))

--- a/README.md
+++ b/README.md
@@ -1,22 +1,38 @@
-# README
+# Confy
+Where the meetings are.
 
-## Configuration
+## Pre-Requisites
+- Ruby (version located on [Gemfile](./Gemfile))
+- Docker (follow the [Docker Guide](https://docs.docker.com/install/) for your OS)
+- Docker Compose (find how to install it in the [Docker Compose Guide](https://docs.docker.com/compose/install/))
 
-#### Install docker:
-> \# apt install docker
->
-> \# apt install docker-compose
+## Set Up App and Database
 
-#### Create
-> $ docker-compose build
+Run the following commands
 
-> $ docker-compose run web yarn install
+```
+docker-compose build
 
-> $ docker-compose run web rake db:create
->
-> $ docker-compose run web rake db:migrate
->
-> $ docker-compose run web rake db:seed
+docker-compose run web yarn install
 
-#### Execute
-> $ docker-compose up
+docker-compose run web rake db:create
+
+docker-compose run web rake db:migrate
+
+docker-compose run web rake db:seed
+```
+
+## Run the application
+
+```
+docker-compose up
+```
+
+## Troubleshoot
+
+### `docker-compose` issues
+If you have problems running the `docker-compose` commands you may want to try running them with `sudo` in order to fix the problem.
+
+### Ruby version mismatch when running `docker-compose build`
+If you encounter an issue regarding Ruby versions, make sure you have the Ruby version indicated in the [Gemfile](./Gemfile) and [DockerFile](./Dockerfile) (both should be equal) and if you still have issues you can try running `gem update bundler`
+


### PR DESCRIPTION
- Seteo version en Dockerfile de Ruby a `2.5.3` porque puede causar problemas (habia actualizado la version, pero para no romper la build en el server, si se hace, se hace en otro parche para eso)
- Cambios en Readme para dejar la instalacion de Docker en manos de la guia oficial para cada sistema operativo. 
- Los comandos formateados correctamente
- Seccion de troubleshoot con algunos problemas que encontre.
- Seccion de pre-requisitos mejor formada.